### PR TITLE
v1.0.1 released.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rhosocial/go-dag
 
 go 1.20
 
-require github.com/stretchr/testify v1.8.4
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/workflow/simple/dag_test.go
+++ b/workflow/simple/dag_test.go
@@ -1044,7 +1044,7 @@ func TestCancelWorkflowByCtx(t *testing.T) {
 			ch1 <- struct{}{}
 		}()
 		<-ch1
-		time.Sleep(time.Millisecond)
+		time.Sleep(time.Millisecond * 100)
 
 		errors1 := errorCollector.Get()
 		assert.Len(t, errors1, 2)


### PR DESCRIPTION
Solved #10.

The v1.0.0 and the earlier versions are not recommended to use.